### PR TITLE
Add from __future__ import annotations to files missing this import

### DIFF
--- a/src/pytomography/callbacks/callback.py
+++ b/src/pytomography/callbacks/callback.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import abc
 import torch
 

--- a/src/pytomography/mappings/mapping.py
+++ b/src/pytomography/mappings/mapping.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import abc
 import torch
 import torch.nn as nn

--- a/src/pytomography/priors/prior.py
+++ b/src/pytomography/priors/prior.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import torch
 import torch.nn as nn
 import numpy as np

--- a/src/pytomography/priors/relative_difference.py
+++ b/src/pytomography/priors/relative_difference.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import torch
 import torch.nn as nn
 import numpy as np

--- a/src/pytomography/priors/smoothness.py
+++ b/src/pytomography/priors/smoothness.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import torch
 import torch.nn as nn
 import numpy as np

--- a/src/pytomography/projections/forward_projection.py
+++ b/src/pytomography/projections/forward_projection.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import torch
 from pytomography.utils import rotate_detector_z, pad_object, unpad_image
 from .projection import ProjectionNet

--- a/src/pytomography/projections/projection.py
+++ b/src/pytomography/projections/projection.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import torch.nn as nn
 import abc
 import pytomography


### PR DESCRIPTION
This is to ensure versions of `python<3.9` can also use all PyTomography functionalities.  